### PR TITLE
Fix Base64 decoding for PR analyzer

### DIFF
--- a/pr-analyzer-service/src/main/kotlin/com/ai/coderoute/pranalyzer/service/PullRequestProcessor.kt
+++ b/pr-analyzer-service/src/main/kotlin/com/ai/coderoute/pranalyzer/service/PullRequestProcessor.kt
@@ -23,7 +23,7 @@ class PullRequestProcessor(
                     githubApi.getFileContent(event.owner, event.repo, changedFile.filename, event.headSha)
                         .subscribe { fileContent ->
                             val decodedContent =
-                                Base64.getDecoder().decode(fileContent.content).toString(Charsets.UTF_8)
+                                Base64.getDecoder().decode(fileContent.content).decodeToString()
                             val numberedContent =
                                 decodedContent.lines().mapIndexed { index, line -> "${index + 1}: $line" }
                                     .joinToString("\n")


### PR DESCRIPTION
## Summary
- decode Base64 file content using UTF-8 string conversion

## Testing
- `mvn -q -pl pr-analyzer-service -am test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e9226888328b2d1c7f7ab88136d