### PR TITLE
Capture GitHub comment events and store per PR

### DIFF
--- a/comment-persistence-service/pom.xml
+++ b/comment-persistence-service/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.ai</groupId>
+        <artifactId>coderoute</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>comment-persistence-service</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <kotlin.code.style>official</kotlin.code.style>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>mavenCentral</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <mainClass>MainKt</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>core-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/CommentPersistenceServiceApplication.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/CommentPersistenceServiceApplication.kt
@@ -1,0 +1,11 @@
+package com.ai.coderoute.commentpersistence
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class CommentPersistenceServiceApplication
+
+fun main(args: Array<String>) {
+    runApplication<CommentPersistenceServiceApplication>(*args)
+}

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/CommentEntity.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/CommentEntity.kt
@@ -1,0 +1,27 @@
+package com.ai.coderoute.commentpersistence.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "comments")
+class CommentEntity(
+    @Id
+    var id: Long = 0,
+    var author: String = "",
+    var updatedAt: Instant = Instant.EPOCH,
+    var path: String? = null,
+    var line: Int? = null,
+    @Column(columnDefinition = "TEXT")
+    var body: String = "",
+    var inThread: Boolean = false,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pull_request_id")
+    var pullRequest: PullRequestEntity = PullRequestEntity(),
+)

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/PullRequestEntity.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/PullRequestEntity.kt
@@ -1,0 +1,22 @@
+package com.ai.coderoute.commentpersistence.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "pull_requests",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["owner", "repo", "number"])],
+)
+class PullRequestEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+    var owner: String = "",
+    var repo: String = "",
+    var number: Int = 0,
+)

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/listener/CommentEventListener.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/listener/CommentEventListener.kt
@@ -1,0 +1,17 @@
+package com.ai.coderoute.commentpersistence.listener
+
+import com.ai.coderoute.commentpersistence.service.CommentPersistenceService
+import com.ai.coderoute.constants.Events
+import com.ai.coderoute.models.PullRequestCommentEvent
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+@Component
+class CommentEventListener(
+    private val service: CommentPersistenceService,
+) {
+    @KafkaListener(topics = [Events.Comment.RECEIVED], groupId = "comment-persistence-group")
+    fun onComment(event: PullRequestCommentEvent) {
+        service.handle(event)
+    }
+}

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/CommentRepository.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/CommentRepository.kt
@@ -1,0 +1,6 @@
+package com.ai.coderoute.commentpersistence.repository
+
+import com.ai.coderoute.commentpersistence.entity.CommentEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository : JpaRepository<CommentEntity, Long>

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/PullRequestRepository.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/PullRequestRepository.kt
@@ -1,0 +1,8 @@
+package com.ai.coderoute.commentpersistence.repository
+
+import com.ai.coderoute.commentpersistence.entity.PullRequestEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PullRequestRepository : JpaRepository<PullRequestEntity, Long> {
+    fun findByOwnerAndRepoAndNumber(owner: String, repo: String, number: Int): PullRequestEntity?
+}

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/service/CommentPersistenceService.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/service/CommentPersistenceService.kt
@@ -1,0 +1,38 @@
+package com.ai.coderoute.commentpersistence.service
+
+import com.ai.coderoute.commentpersistence.entity.CommentEntity
+import com.ai.coderoute.commentpersistence.entity.PullRequestEntity
+import com.ai.coderoute.commentpersistence.repository.CommentRepository
+import com.ai.coderoute.commentpersistence.repository.PullRequestRepository
+import com.ai.coderoute.models.PullRequestCommentEvent
+import org.springframework.stereotype.Service
+
+@Service
+class CommentPersistenceService(
+    private val commentRepository: CommentRepository,
+    private val pullRequestRepository: PullRequestRepository,
+) {
+    fun handle(event: PullRequestCommentEvent) {
+        val pr =
+            pullRequestRepository.findByOwnerAndRepoAndNumber(event.owner, event.repo, event.pullNumber)
+                ?: pullRequestRepository.save(
+                    PullRequestEntity(owner = event.owner, repo = event.repo, number = event.pullNumber),
+                )
+        when (event.action) {
+            "created", "edited" -> {
+                val entity = commentRepository.findById(event.commentId).orElse(CommentEntity(id = event.commentId, pullRequest = pr))
+                entity.author = event.author
+                entity.body = event.body ?: ""
+                entity.path = event.filePath
+                entity.line = event.line
+                entity.inThread = event.inThread
+                entity.updatedAt = event.updatedAt
+                entity.pullRequest = pr
+                commentRepository.save(entity)
+            }
+            "deleted" -> {
+                commentRepository.findById(event.commentId).ifPresent { commentRepository.delete(it) }
+            }
+        }
+    }
+}

--- a/comment-persistence-service/src/main/resources/application.properties
+++ b/comment-persistence-service/src/main/resources/application.properties
@@ -1,0 +1,16 @@
+# ===================================================================
+# APPLICATION SETTINGS
+# ===================================================================
+spring.application.name=comment-persistence-service
+server.port=8084
+
+spring.config.import=classpath:application-common.properties
+
+# ===================================================================
+# DATABASE CONFIGURATION
+# ===================================================================
+spring.datasource.url=jdbc:h2:mem:commentdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update

--- a/comment-persistence-service/src/test/kotlin/com/ai/coderoute/commentpersistence/service/CommentPersistenceServiceTest.kt
+++ b/comment-persistence-service/src/test/kotlin/com/ai/coderoute/commentpersistence/service/CommentPersistenceServiceTest.kt
@@ -1,0 +1,40 @@
+package com.ai.coderoute.commentpersistence.service
+
+import com.ai.coderoute.commentpersistence.repository.CommentRepository
+import com.ai.coderoute.commentpersistence.repository.PullRequestRepository
+import com.ai.coderoute.models.PullRequestCommentEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import java.time.Instant
+
+@DataJpaTest
+class CommentPersistenceServiceTest @Autowired constructor(
+    private val commentRepository: CommentRepository,
+    private val pullRequestRepository: PullRequestRepository,
+) {
+    private val service = CommentPersistenceService(commentRepository, pullRequestRepository)
+
+    @Test
+    fun `duplicate comment events do not create multiple records`() {
+        val event =
+            PullRequestCommentEvent(
+                action = "created",
+                commentId = 1,
+                owner = "owner",
+                repo = "repo",
+                pullNumber = 1,
+                author = "user",
+                body = "body",
+                filePath = "file",
+                line = 1,
+                inThread = false,
+                updatedAt = Instant.now(),
+            )
+        service.handle(event)
+        service.handle(event)
+        assertEquals(1, commentRepository.count())
+        assertEquals(1, pullRequestRepository.count())
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -61,6 +61,19 @@ services:
       - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - SPRING_DATA_MONGODB_URI=mongodb://mongo:27017/coderoute
 
+  comment-persistence:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE_NAME: comment-persistence-service
+        SERVICE_PORT: 8084
+    container_name: comment-persistence-app
+    depends_on:
+      - kafka
+    environment:
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+
   # 2. Backing Infrastructure Services
   ollama:
     image: ollama/ollama

--- a/core/src/main/kotlin/com/ai/coderoute/constants/Events.kt
+++ b/core/src/main/kotlin/com/ai/coderoute/constants/Events.kt
@@ -15,4 +15,9 @@ object Events {
         const val REVIEW_COMPLETE = "ai.review.complete"
         const val REVIEW_COMPLETE_KEY = "ai.review.complete.key"
     }
+
+    object Comment {
+        const val RECEIVED = "pr.comment.received"
+        const val RECEIVED_KEY = "pr.comment.received.key"
+    }
 }

--- a/core/src/main/kotlin/com/ai/coderoute/models/PullRequestCommentEvent.kt
+++ b/core/src/main/kotlin/com/ai/coderoute/models/PullRequestCommentEvent.kt
@@ -1,0 +1,17 @@
+package com.ai.coderoute.models
+
+import java.time.Instant
+
+data class PullRequestCommentEvent(
+    val action: String,
+    val commentId: Long,
+    val owner: String,
+    val repo: String,
+    val pullNumber: Int,
+    val author: String,
+    val body: String?,
+    val filePath: String?,
+    val line: Int?,
+    val inThread: Boolean,
+    val updatedAt: Instant,
+)

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,9 @@
 		<module>webhook-handler-service</module>
 		<module>pr-analyzer-service</module>
 		<module>ai-reviewer-service</module>
-		<module>comment-publisher-service</module>
-		<module>core</module>
+                <module>comment-publisher-service</module>
+                <module>comment-persistence-service</module>
+                <module>core</module>
 		<module>core-config</module>
 	</modules>
 	<scm>

--- a/webhook-handler-service/pom.xml
+++ b/webhook-handler-service/pom.xml
@@ -85,16 +85,16 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.kafka</groupId>
-			<artifactId>spring-kafka</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.kafka</groupId>
+                        <artifactId>spring-kafka</artifactId>
+                </dependency>
 
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>core</artifactId>
-			<version>${project.version}</version>
-		</dependency>
+                <dependency>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>core</artifactId>
+                        <version>${project.version}</version>
+                </dependency>
 
 	</dependencies>
 

--- a/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/controller/GithubWebhookController.kt
+++ b/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/controller/GithubWebhookController.kt
@@ -29,6 +29,8 @@ class GithubWebhookController
             when (eventType) {
                 "ping" -> webhookService.handlePing(jsonNode)
                 "pull_request" -> webhookService.handlePullRequest(jsonNode)
+                "pull_request_review_comment" -> webhookService.handlePullRequestReviewComment(jsonNode)
+                "issue_comment" -> webhookService.handleIssueComment(jsonNode)
                 else -> logger.error("Unhandled event: $eventType")
             }
         }

--- a/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/models/GithubModels.kt
+++ b/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/models/GithubModels.kt
@@ -50,3 +50,51 @@ data class Head(
     @JsonProperty("sha")
     val sha: String,
 )
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GitHubReviewCommentPayload(
+    @JsonProperty("action") val action: String,
+    @JsonProperty("repository") val repository: Repository,
+    @JsonProperty("pull_request") val pullRequest: PullRequest,
+    @JsonProperty("comment") val comment: ReviewComment,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ReviewComment(
+    @JsonProperty("id") val id: Long,
+    @JsonProperty("user") val user: User,
+    @JsonProperty("body") val body: String,
+    @JsonProperty("path") val path: String? = null,
+    @JsonProperty("line") val line: Int? = null,
+    @JsonProperty("in_reply_to_id") val inReplyToId: Long? = null,
+    @JsonProperty("created_at") val createdAt: String,
+    @JsonProperty("updated_at") val updatedAt: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GitHubIssueCommentPayload(
+    @JsonProperty("action") val action: String,
+    @JsonProperty("repository") val repository: Repository,
+    @JsonProperty("issue") val issue: Issue,
+    @JsonProperty("comment") val comment: IssueComment,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class IssueComment(
+    @JsonProperty("id") val id: Long,
+    @JsonProperty("user") val user: User,
+    @JsonProperty("body") val body: String,
+    @JsonProperty("created_at") val createdAt: String,
+    @JsonProperty("updated_at") val updatedAt: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class User(
+    @JsonProperty("login") val login: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Issue(
+    @JsonProperty("number") val number: Int,
+    @JsonProperty("pull_request") val pullRequest: Any? = null,
+)

--- a/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/service/CommentEventPublisher.kt
+++ b/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/service/CommentEventPublisher.kt
@@ -1,0 +1,24 @@
+package com.ai.coderoute.webhookhandler.service
+
+import com.ai.coderoute.constants.Events
+import com.ai.coderoute.models.PullRequestCommentEvent
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class CommentEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, PullRequestCommentEvent>,
+) {
+    private val logger = LoggerFactory.getLogger(CommentEventPublisher::class.java)
+    private val topic = Events.Comment.RECEIVED
+
+    fun publish(event: PullRequestCommentEvent) {
+        try {
+            kafkaTemplate.send(topic, Events.Comment.RECEIVED_KEY, event)
+            logger.info("Published comment event {}", event.commentId)
+        } catch (e: Exception) {
+            logger.error("Failed to publish comment event {}", event.commentId, e)
+        }
+    }
+}

--- a/webhook-handler-service/src/main/resources/application.properties
+++ b/webhook-handler-service/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.application.name=webhook-handler-service
 server.port=8079
 
 spring.config.import=classpath:application-common.properties
+


### PR DESCRIPTION
## Summary
- produce `PullRequestCommentEvent` on review or issue comments and publish to Kafka
- add `comment-persistence-service` that consumes comment events and stores them via JPA
- wire new service into docker-compose alongside existing services

## Testing
- `mvn -q -pl core,webhook-handler-service,comment-persistence-service -am test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a07feeb22c8328841cb8ad1b0e81da