### PR TITLE
Track review thread resolution events

### DIFF
--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/PullRequestEntity.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/PullRequestEntity.kt
@@ -19,4 +19,5 @@ class PullRequestEntity(
     var owner: String = "",
     var repo: String = "",
     var number: Int = 0,
+    var unresolvedCount: Int = 0,
 )

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/ReviewThreadEntity.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/ReviewThreadEntity.kt
@@ -1,0 +1,21 @@
+package com.ai.coderoute.commentpersistence.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "review_threads")
+class ReviewThreadEntity(
+    @Id
+    var id: Long = 0,
+
+    @ManyToOne(optional = false)
+    var pullRequest: PullRequestEntity? = null,
+
+    var resolvedBy: String? = null,
+    var resolvedAt: Instant? = null,
+    var resolved: Boolean = false,
+)

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/listener/ReviewThreadEventListener.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/listener/ReviewThreadEventListener.kt
@@ -1,0 +1,17 @@
+package com.ai.coderoute.commentpersistence.listener
+
+import com.ai.coderoute.commentpersistence.service.ReviewThreadPersistenceService
+import com.ai.coderoute.constants.Events
+import com.ai.coderoute.models.PullRequestReviewThreadEvent
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+@Component
+class ReviewThreadEventListener(
+    private val service: ReviewThreadPersistenceService,
+) {
+    @KafkaListener(topics = [Events.ReviewThread.RECEIVED], groupId = "comment-persistence-group")
+    fun onReviewThread(event: PullRequestReviewThreadEvent) {
+        service.handle(event)
+    }
+}

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/ReviewThreadRepository.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/ReviewThreadRepository.kt
@@ -1,0 +1,6 @@
+package com.ai.coderoute.commentpersistence.repository
+
+import com.ai.coderoute.commentpersistence.entity.ReviewThreadEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReviewThreadRepository : JpaRepository<ReviewThreadEntity, Long>

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/service/ReviewThreadPersistenceService.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/service/ReviewThreadPersistenceService.kt
@@ -1,0 +1,49 @@
+package com.ai.coderoute.commentpersistence.service
+
+import com.ai.coderoute.commentpersistence.entity.PullRequestEntity
+import com.ai.coderoute.commentpersistence.entity.ReviewThreadEntity
+import com.ai.coderoute.commentpersistence.repository.PullRequestRepository
+import com.ai.coderoute.commentpersistence.repository.ReviewThreadRepository
+import com.ai.coderoute.models.PullRequestReviewThreadEvent
+import org.springframework.stereotype.Service
+
+@Service
+class ReviewThreadPersistenceService(
+    private val reviewThreadRepository: ReviewThreadRepository,
+    private val pullRequestRepository: PullRequestRepository,
+) {
+    fun handle(event: PullRequestReviewThreadEvent) {
+        val pr =
+            pullRequestRepository.findByOwnerAndRepoAndNumber(event.owner, event.repo, event.pullNumber)
+                ?: pullRequestRepository.save(
+                    PullRequestEntity(owner = event.owner, repo = event.repo, number = event.pullNumber),
+                )
+
+        val thread =
+            reviewThreadRepository.findById(event.threadId)
+                .orElse(ReviewThreadEntity(id = event.threadId, pullRequest = pr))
+
+        when (event.action) {
+            "resolved" -> {
+                if (!thread.resolved) {
+                    pr.unresolvedCount = (pr.unresolvedCount - 1).coerceAtLeast(0)
+                }
+                thread.resolved = true
+                thread.resolvedBy = event.resolvedBy
+                thread.resolvedAt = event.resolvedAt
+            }
+            "unresolved", "reopened" -> {
+                if (thread.resolved) {
+                    pr.unresolvedCount = pr.unresolvedCount + 1
+                }
+                thread.resolved = false
+                thread.resolvedBy = null
+                thread.resolvedAt = null
+            }
+        }
+
+        thread.pullRequest = pr
+        reviewThreadRepository.save(thread)
+        pullRequestRepository.save(pr)
+    }
+}

--- a/comment-persistence-service/src/test/kotlin/com/ai/coderoute/commentpersistence/service/ReviewThreadPersistenceServiceTest.kt
+++ b/comment-persistence-service/src/test/kotlin/com/ai/coderoute/commentpersistence/service/ReviewThreadPersistenceServiceTest.kt
@@ -1,0 +1,54 @@
+package com.ai.coderoute.commentpersistence.service
+
+import com.ai.coderoute.commentpersistence.repository.PullRequestRepository
+import com.ai.coderoute.commentpersistence.repository.ReviewThreadRepository
+import com.ai.coderoute.models.PullRequestReviewThreadEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import java.time.Instant
+
+@DataJpaTest
+class ReviewThreadPersistenceServiceTest @Autowired constructor(
+    private val reviewThreadRepository: ReviewThreadRepository,
+    private val pullRequestRepository: PullRequestRepository,
+) {
+    private val service = ReviewThreadPersistenceService(reviewThreadRepository, pullRequestRepository)
+
+    @Test
+    fun `unresolved and resolved events adjust counts`() {
+        val reopenEvent =
+            PullRequestReviewThreadEvent(
+                action = "reopened",
+                threadId = 1,
+                owner = "owner",
+                repo = "repo",
+                pullNumber = 1,
+                resolvedBy = null,
+                resolvedAt = null,
+            )
+        service.handle(reopenEvent)
+
+        var pr = pullRequestRepository.findByOwnerAndRepoAndNumber("owner", "repo", 1)!!
+        assertEquals(1, pr.unresolvedCount)
+
+        val resolvedEvent =
+            PullRequestReviewThreadEvent(
+                action = "resolved",
+                threadId = 1,
+                owner = "owner",
+                repo = "repo",
+                pullNumber = 1,
+                resolvedBy = "user",
+                resolvedAt = Instant.now(),
+            )
+        service.handle(resolvedEvent)
+
+        val thread = reviewThreadRepository.findById(1).get()
+        pr = pullRequestRepository.findByOwnerAndRepoAndNumber("owner", "repo", 1)!!
+        assertEquals(0, pr.unresolvedCount)
+        assertEquals(true, thread.resolved)
+        assertEquals("user", thread.resolvedBy)
+    }
+}

--- a/core/src/main/kotlin/com/ai/coderoute/constants/Events.kt
+++ b/core/src/main/kotlin/com/ai/coderoute/constants/Events.kt
@@ -20,4 +20,9 @@ object Events {
         const val RECEIVED = "pr.comment.received"
         const val RECEIVED_KEY = "pr.comment.received.key"
     }
+
+    object ReviewThread {
+        const val RECEIVED = "pr.review_thread.received"
+        const val RECEIVED_KEY = "pr.review_thread.received.key"
+    }
 }

--- a/core/src/main/kotlin/com/ai/coderoute/models/PullRequestReviewThreadEvent.kt
+++ b/core/src/main/kotlin/com/ai/coderoute/models/PullRequestReviewThreadEvent.kt
@@ -1,0 +1,13 @@
+package com.ai.coderoute.models
+
+import java.time.Instant
+
+data class PullRequestReviewThreadEvent(
+    val action: String,
+    val threadId: Long,
+    val owner: String,
+    val repo: String,
+    val pullNumber: Int,
+    val resolvedBy: String?,
+    val resolvedAt: Instant?,
+)

--- a/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/controller/GithubWebhookController.kt
+++ b/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/controller/GithubWebhookController.kt
@@ -30,6 +30,7 @@ class GithubWebhookController
                 "ping" -> webhookService.handlePing(jsonNode)
                 "pull_request" -> webhookService.handlePullRequest(jsonNode)
                 "pull_request_review_comment" -> webhookService.handlePullRequestReviewComment(jsonNode)
+                "pull_request_review_thread" -> webhookService.handlePullRequestReviewThread(jsonNode)
                 "issue_comment" -> webhookService.handleIssueComment(jsonNode)
                 else -> logger.error("Unhandled event: $eventType")
             }

--- a/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/models/GithubModels.kt
+++ b/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/models/GithubModels.kt
@@ -98,3 +98,19 @@ data class Issue(
     @JsonProperty("number") val number: Int,
     @JsonProperty("pull_request") val pullRequest: Any? = null,
 )
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GitHubReviewThreadPayload(
+    @JsonProperty("action") val action: String,
+    @JsonProperty("repository") val repository: Repository,
+    @JsonProperty("pull_request") val pullRequest: PullRequest,
+    @JsonProperty("thread") val thread: ReviewThread,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ReviewThread(
+    @JsonProperty("id") val id: Long,
+    @JsonProperty("resolved") val resolved: Boolean? = null,
+    @JsonProperty("resolved_by") val resolvedBy: User? = null,
+    @JsonProperty("resolved_at") val resolvedAt: String? = null,
+)

--- a/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/service/GitHubWebhookService.kt
+++ b/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/service/GitHubWebhookService.kt
@@ -2,9 +2,11 @@ package com.ai.coderoute.webhookhandler.service
 
 import com.ai.coderoute.models.PullRequestReceivedEvent
 import com.ai.coderoute.models.PullRequestCommentEvent
+import com.ai.coderoute.models.PullRequestReviewThreadEvent
 import com.ai.coderoute.webhookhandler.models.GitHubIssueCommentPayload
 import com.ai.coderoute.webhookhandler.models.GitHubPullRequestPayload
 import com.ai.coderoute.webhookhandler.models.GitHubReviewCommentPayload
+import com.ai.coderoute.webhookhandler.models.GitHubReviewThreadPayload
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
@@ -19,6 +21,7 @@ class GitHubWebhookService
         private val objectMapper: ObjectMapper,
         val eventPublisher: WebhookEventPublisher,
         private val commentEventPublisher: CommentEventPublisher,
+        private val reviewThreadEventPublisher: ReviewThreadEventPublisher,
     ) {
         private val logger = LoggerFactory.getLogger(GitHubWebhookService::class.java)
 
@@ -51,6 +54,24 @@ class GitHubWebhookService
                     updatedAt = Instant.parse(event.comment.updatedAt),
                 )
             commentEventPublisher.publish(commentEvent)
+        }
+
+        fun handlePullRequestReviewThread(payload: JsonNode) {
+            val event = objectMapper.treeToValue(payload, GitHubReviewThreadPayload::class.java)
+            if (event.action !in listOf("resolved", "unresolved", "reopened")) {
+                return
+            }
+            val threadEvent =
+                PullRequestReviewThreadEvent(
+                    action = event.action,
+                    threadId = event.thread.id,
+                    owner = event.repository.owner.login,
+                    repo = event.repository.name,
+                    pullNumber = event.pullRequest.number,
+                    resolvedBy = event.thread.resolvedBy?.login,
+                    resolvedAt = event.thread.resolvedAt?.let { Instant.parse(it) },
+                )
+            reviewThreadEventPublisher.publish(threadEvent)
         }
 
         fun handleIssueComment(payload: JsonNode) {

--- a/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/service/ReviewThreadEventPublisher.kt
+++ b/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/service/ReviewThreadEventPublisher.kt
@@ -1,0 +1,24 @@
+package com.ai.coderoute.webhookhandler.service
+
+import com.ai.coderoute.constants.Events
+import com.ai.coderoute.models.PullRequestReviewThreadEvent
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class ReviewThreadEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, PullRequestReviewThreadEvent>,
+) {
+    private val logger = LoggerFactory.getLogger(ReviewThreadEventPublisher::class.java)
+    private val topic = Events.ReviewThread.RECEIVED
+
+    fun publish(event: PullRequestReviewThreadEvent) {
+        try {
+            kafkaTemplate.send(topic, Events.ReviewThread.RECEIVED_KEY, event)
+            logger.info("Published review thread event {}", event.threadId)
+        } catch (e: Exception) {
+            logger.error("Failed to publish review thread event {}", event.threadId, e)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- handle pull_request_review_thread webhook events and publish to Kafka
- persist thread resolution state and unresolved counts per PR

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0853435d8832893f4abc22ea8c5d6