### PR TITLE
Expose review thread endpoints with unresolved counts

### DIFF
--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/controller/PullRequestController.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/controller/PullRequestController.kt
@@ -1,0 +1,79 @@
+package com.ai.coderoute.commentpersistence.controller
+
+import com.ai.coderoute.commentpersistence.entity.CommentEntity
+import com.ai.coderoute.commentpersistence.repository.CommentRepository
+import com.ai.coderoute.commentpersistence.repository.PullRequestRepository
+import com.ai.coderoute.commentpersistence.repository.ReviewThreadRepository
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/pr")
+class PullRequestController(
+    private val pullRequestRepository: PullRequestRepository,
+    private val reviewThreadRepository: ReviewThreadRepository,
+    private val commentRepository: CommentRepository,
+) {
+    @GetMapping("/{owner}/{repo}/{number}/unresolved-count")
+    fun unresolvedCount(
+        @PathVariable owner: String,
+        @PathVariable repo: String,
+        @PathVariable number: Int,
+    ): UnresolvedCountResponse {
+        val pr = pullRequestRepository.findByOwnerAndRepoAndNumber(owner, repo, number)
+        return UnresolvedCountResponse(pr?.unresolvedCount ?: 0)
+    }
+
+    @GetMapping("/{owner}/{repo}/{number}/threads")
+    fun threads(
+        @PathVariable owner: String,
+        @PathVariable repo: String,
+        @PathVariable number: Int,
+    ): List<ReviewThreadResponse> {
+        val threads = reviewThreadRepository.findByPullRequestOwnerAndPullRequestRepoAndPullRequestNumber(owner, repo, number)
+        return threads.map { thread ->
+            val comments = commentRepository
+                .findByPullRequestOwnerAndPullRequestRepoAndPullRequestNumberAndThreadId(owner, repo, number, thread.id)
+                .map { it.toDto() }
+            ReviewThreadResponse(
+                id = thread.id,
+                resolved = thread.resolved,
+                resolvedBy = thread.resolvedBy,
+                resolvedAt = thread.resolvedAt,
+                comments = comments,
+            )
+        }
+    }
+
+    private fun CommentEntity.toDto() =
+        CommentResponse(
+            id = id,
+            author = author,
+            body = body,
+            path = path,
+            line = line,
+            updatedAt = updatedAt,
+        )
+}
+
+data class ReviewThreadResponse(
+    val id: Long,
+    val resolved: Boolean,
+    val resolvedBy: String?,
+    val resolvedAt: java.time.Instant?,
+    val comments: List<CommentResponse>,
+)
+
+data class CommentResponse(
+    val id: Long,
+    val author: String,
+    val body: String,
+    val path: String?,
+    val line: Int?,
+    val updatedAt: java.time.Instant,
+)
+
+data class UnresolvedCountResponse(val unresolvedCount: Int)
+

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/CommentEntity.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/entity/CommentEntity.kt
@@ -20,6 +20,7 @@ class CommentEntity(
     var line: Int? = null,
     @Column(columnDefinition = "TEXT")
     var body: String = "",
+    var threadId: Long? = null,
     var inThread: Boolean = false,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pull_request_id")

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/CommentRepository.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/CommentRepository.kt
@@ -3,4 +3,11 @@ package com.ai.coderoute.commentpersistence.repository
 import com.ai.coderoute.commentpersistence.entity.CommentEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CommentRepository : JpaRepository<CommentEntity, Long>
+interface CommentRepository : JpaRepository<CommentEntity, Long> {
+    fun findByPullRequestOwnerAndPullRequestRepoAndPullRequestNumberAndThreadId(
+        owner: String,
+        repo: String,
+        number: Int,
+        threadId: Long,
+    ): List<CommentEntity>
+}

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/ReviewThreadRepository.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/repository/ReviewThreadRepository.kt
@@ -3,4 +3,10 @@ package com.ai.coderoute.commentpersistence.repository
 import com.ai.coderoute.commentpersistence.entity.ReviewThreadEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ReviewThreadRepository : JpaRepository<ReviewThreadEntity, Long>
+interface ReviewThreadRepository : JpaRepository<ReviewThreadEntity, Long> {
+    fun findByPullRequestOwnerAndPullRequestRepoAndPullRequestNumber(
+        owner: String,
+        repo: String,
+        number: Int,
+    ): List<ReviewThreadEntity>
+}

--- a/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/service/CommentPersistenceService.kt
+++ b/comment-persistence-service/src/main/kotlin/com/ai/coderoute/commentpersistence/service/CommentPersistenceService.kt
@@ -25,6 +25,7 @@ class CommentPersistenceService(
                 entity.body = event.body ?: ""
                 entity.path = event.filePath
                 entity.line = event.line
+                entity.threadId = event.threadId
                 entity.inThread = event.inThread
                 entity.updatedAt = event.updatedAt
                 entity.pullRequest = pr

--- a/comment-persistence-service/src/main/resources/static/index.html
+++ b/comment-persistence-service/src/main/resources/static/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>PR Threads</title>
+  <style>
+    .badge { background: #d33; color: #fff; padding: 2px 6px; border-radius: 12px; }
+    .thread { border: 1px solid #ccc; margin: 10px 0; }
+    .thread-header { padding: 5px; cursor: pointer; background: #f0f0f0; }
+    .comments { display: none; padding: 5px 10px; }
+  </style>
+</head>
+<body>
+  <h1>Pull Request Threads</h1>
+  <div>Unresolved Threads: <span id="unresolvedCount" class="badge">0</span></div>
+  <div id="threads"></div>
+  <script>
+    async function load() {
+      const params = new URLSearchParams(window.location.search);
+      const owner = params.get('owner');
+      const repo = params.get('repo');
+      const number = params.get('number');
+      if (!owner || !repo || !number) {
+        return;
+      }
+      const base = `/api/v1/pr/${owner}/${repo}/${number}`;
+      const countResp = await fetch(`${base}/unresolved-count`);
+      const countData = await countResp.json();
+      document.getElementById('unresolvedCount').textContent = countData.unresolvedCount;
+      const threadsResp = await fetch(`${base}/threads`);
+      const allThreads = await threadsResp.json();
+      const container = document.getElementById('threads');
+      allThreads.filter(t => !t.resolved).forEach(t => {
+        const tDiv = document.createElement('div');
+        tDiv.className = 'thread';
+        const header = document.createElement('div');
+        header.className = 'thread-header';
+        header.textContent = `Thread #${t.id}`;
+        const commentsDiv = document.createElement('div');
+        commentsDiv.className = 'comments';
+        t.comments.forEach(c => {
+          const p = document.createElement('p');
+          const a = document.createElement('a');
+          if (c.path && c.line) {
+            a.href = `${c.path}#L${c.line}`;
+          } else {
+            a.href = '#';
+          }
+          a.textContent = c.body;
+          p.appendChild(a);
+          commentsDiv.appendChild(p);
+        });
+        header.addEventListener('click', () => {
+          commentsDiv.style.display = commentsDiv.style.display === 'none' ? 'block' : 'none';
+        });
+        tDiv.appendChild(header);
+        tDiv.appendChild(commentsDiv);
+        container.appendChild(tDiv);
+      });
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/comment-persistence-service/src/test/kotlin/com/ai/coderoute/commentpersistence/service/CommentPersistenceServiceTest.kt
+++ b/comment-persistence-service/src/test/kotlin/com/ai/coderoute/commentpersistence/service/CommentPersistenceServiceTest.kt
@@ -29,6 +29,7 @@ class CommentPersistenceServiceTest @Autowired constructor(
                 body = "body",
                 filePath = "file",
                 line = 1,
+                threadId = 1,
                 inThread = false,
                 updatedAt = Instant.now(),
             )
@@ -36,5 +37,7 @@ class CommentPersistenceServiceTest @Autowired constructor(
         service.handle(event)
         assertEquals(1, commentRepository.count())
         assertEquals(1, pullRequestRepository.count())
+        val saved = commentRepository.findById(1).get()
+        assertEquals(1, saved.threadId)
     }
 }

--- a/core/src/main/kotlin/com/ai/coderoute/models/PullRequestCommentEvent.kt
+++ b/core/src/main/kotlin/com/ai/coderoute/models/PullRequestCommentEvent.kt
@@ -12,6 +12,7 @@ data class PullRequestCommentEvent(
     val body: String?,
     val filePath: String?,
     val line: Int?,
+    val threadId: Long?,
     val inThread: Boolean,
     val updatedAt: Instant,
 )

--- a/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/service/GitHubWebhookService.kt
+++ b/webhook-handler-service/src/main/kotlin/com/ai/coderoute/webhookhandler/service/GitHubWebhookService.kt
@@ -39,6 +39,7 @@ class GitHubWebhookService
 
         fun handlePullRequestReviewComment(payload: JsonNode) {
             val event = objectMapper.treeToValue(payload, GitHubReviewCommentPayload::class.java)
+            val threadId = event.comment.inReplyToId ?: event.comment.id
             val commentEvent =
                 PullRequestCommentEvent(
                     action = event.action,
@@ -50,6 +51,7 @@ class GitHubWebhookService
                     body = event.comment.body,
                     filePath = event.comment.path,
                     line = event.comment.line,
+                    threadId = threadId,
                     inThread = event.comment.inReplyToId != null,
                     updatedAt = Instant.parse(event.comment.updatedAt),
                 )
@@ -90,6 +92,7 @@ class GitHubWebhookService
                     body = event.comment.body,
                     filePath = null,
                     line = null,
+                    threadId = null,
                     inThread = false,
                     updatedAt = Instant.parse(event.comment.updatedAt),
                 )


### PR DESCRIPTION
## Summary
- track review thread membership by adding `threadId` to comment events
- persist threadId and expose PR endpoints for unresolved counts and thread details
- add simple static page showing unresolved thread badge and collapsible thread comments

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a08885e2648328853f2550cf6142dc