### PR TITLE
Ensure ReviewComment lists exclude nulls

### DIFF
--- a/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/component/CommentPublisherListener.kt
+++ b/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/component/CommentPublisherListener.kt
@@ -23,7 +23,7 @@ class CommentPublisherListener
         )
         fun onFileAnalysisComplete(event: AnalysisCompleted) {
             println("Received analysis complete event $event")
-            val findings = event.findings.map { ReviewCommentMapper.fromReview(it) }.toList()
+            val findings = event.findings.mapNotNull { ReviewCommentMapper.fromReview(it) }
             coroutineScope.launch {
                 githubCommentPublisher.postReview(
                     event.owner,

--- a/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/service/GithubCommentPublisher.kt
+++ b/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/service/GithubCommentPublisher.kt
@@ -18,7 +18,7 @@ class GithubCommentPublisher
             owner: String,
             repo: String,
             pullNumber: Int,
-            comments: List<ReviewComment?>,
+            comments: List<ReviewComment>,
         ) {
             if (comments.isEmpty()) {
                 println("No comments to post for PR #$pullNumber.")

--- a/core/src/main/kotlin/com/ai/coderoute/models/CreateReviewRequest.kt
+++ b/core/src/main/kotlin/com/ai/coderoute/models/CreateReviewRequest.kt
@@ -3,5 +3,5 @@ package com.ai.coderoute.models
 data class CreateReviewRequest(
     val body: String,
     val event: String = "COMMENT",
-    val comments: List<ReviewComment?>,
+    val comments: List<ReviewComment>,
 )


### PR DESCRIPTION
## Summary
- Filter null review comments before publishing to GitHub
- Require non-null review comments in GithubCommentPublisher
- Update CreateReviewRequest to use non-null comment list

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a090a1615c8328aa4a3fa54b7cdcf3