### PR TITLE
refactor: return non-null findings

### DIFF
--- a/ai-reviewer-service/src/main/kotlin/com/ai/coderoute/aireviewservice/service/LlmReviewService.kt
+++ b/ai-reviewer-service/src/main/kotlin/com/ai/coderoute/aireviewservice/service/LlmReviewService.kt
@@ -18,7 +18,7 @@ class LlmReviewService
         fun reviewCode(
             filename: String,
             fileContent: String,
-        ): List<ReviewFinding?> {
+        ): List<ReviewFinding> {
             val codeBlock =
                 """
                 FILE_PATH: $filename
@@ -33,7 +33,7 @@ class LlmReviewService
                     .messages(listOf(systemMessage, userMessage))
                     .call()
             val data = response.content()
-            logger.info("Sending prompt to AI for file: $data")
+            logger.info("Received AI response for {}", filename)
             return jsonParser.parseFindingList(data)?.reviews ?: emptyList()
         }
     }

--- a/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/component/CommentPublisherListener.kt
+++ b/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/component/CommentPublisherListener.kt
@@ -23,7 +23,7 @@ class CommentPublisherListener
         )
         fun onFileAnalysisComplete(event: AnalysisCompleted) {
             println("Received analysis complete event $event")
-            val findings = event.findings.map { ReviewCommentMapper.fromReview(it) }.toList()
+            val findings = event.findings.mapNotNull { ReviewCommentMapper.fromReview(it) }
             coroutineScope.launch {
                 githubCommentPublisher.postReview(
                     event.owner,

--- a/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/service/GithubCommentPublisher.kt
+++ b/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/service/GithubCommentPublisher.kt
@@ -18,7 +18,7 @@ class GithubCommentPublisher
             owner: String,
             repo: String,
             pullNumber: Int,
-            comments: List<ReviewComment?>,
+            comments: List<ReviewComment>,
         ) {
             if (comments.isEmpty()) {
                 println("No comments to post for PR #$pullNumber.")

--- a/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/utils/ReviewCommentMapper.kt
+++ b/comment-publisher-service/src/main/kotlin/com/ai/coderoute/commentpublisher/utils/ReviewCommentMapper.kt
@@ -4,8 +4,7 @@ import com.ai.coderoute.models.ReviewComment
 import com.ai.coderoute.models.ReviewFinding
 
 object ReviewCommentMapper {
-    fun fromReview(finding: ReviewFinding?): ReviewComment? {
-        if (finding == null) return null
+    fun fromReview(finding: ReviewFinding): ReviewComment? {
         if (finding.lineNumber <= 0) {
             return null
         }

--- a/core/src/main/kotlin/com/ai/coderoute/models/AnalysisCompleted.kt
+++ b/core/src/main/kotlin/com/ai/coderoute/models/AnalysisCompleted.kt
@@ -5,5 +5,5 @@ data class AnalysisCompleted(
     val repo: String,
     val pullNumber: Int,
     val filename: String,
-    val findings: List<ReviewFinding?>,
+    val findings: List<ReviewFinding>,
 )

--- a/core/src/main/kotlin/com/ai/coderoute/models/CreateReviewRequest.kt
+++ b/core/src/main/kotlin/com/ai/coderoute/models/CreateReviewRequest.kt
@@ -3,5 +3,5 @@ package com.ai.coderoute.models
 data class CreateReviewRequest(
     val body: String,
     val event: String = "COMMENT",
-    val comments: List<ReviewComment?>,
+    val comments: List<ReviewComment>,
 )


### PR DESCRIPTION
## Summary
- return non-null review findings from LLM service
- propagate non-null findings through AnalysisCompleted event and comment publishing
- log filename when AI response is received

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a090a0ea248328ba0f3c465c49d107