### PR TITLE
Improve JSON sanitisation in AI reviewer

### DIFF
--- a/ai-reviewer-service/src/test/kotlin/com/ai/coderoute/aireviewservice/component/JsonParserTest.kt
+++ b/ai-reviewer-service/src/test/kotlin/com/ai/coderoute/aireviewservice/component/JsonParserTest.kt
@@ -1,0 +1,35 @@
+package com.ai.coderoute.aireviewservice.component
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class JsonParserTest {
+    private val objectMapper = jacksonObjectMapper()
+    private val parser = JsonParser(objectMapper)
+
+    @Test
+    fun `parseFindingList returns ReviewResponse for valid array`() {
+        val json = """[{"filePath":"src/App.kt","lineNumber":1,"severity":"HIGH","category":"STYLE","ruleId":"R1","message":"msg","suggestion":"sug"}]"""
+        val result = parser.parseFindingList(json)
+        assertNotNull(result)
+        assertEquals(1, result!!.reviews.size)
+        assertEquals("src/App.kt", result.reviews[0].filePath)
+    }
+
+    @Test
+    fun `parseFindingList returns null for malformed json`() {
+        val malformed = """[{"filePath":"src/App.kt""" // missing closing braces
+        val result = parser.parseFindingList(malformed)
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseFindingList returns null for non array input`() {
+        val jsonObject = """{"filePath":"src/App.kt"}"""
+        val result = parser.parseFindingList(jsonObject)
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace fragile string manipulation with array parsing and object wrapping
- Handle malformed or non-array inputs when sanitising JSON
- Add unit tests for valid, malformed, and non-array responses

## Testing
- `./mvnw -q -pl ai-reviewer-service -am test` *(fails: Non-resolvable parent POM due to network unreachable)*
- `./mvnw -o -q -pl ai-reviewer-service -am test` *(fails: Non-resolvable parent POM: missing artifact in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68a0909fef6c83289a6393daef860b26