### PR TITLE
feat: replace H2 with Postgres

### DIFF
--- a/comment-persistence-service/pom.xml
+++ b/comment-persistence-service/pom.xml
@@ -88,8 +88,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/comment-persistence-service/src/main/resources/application.properties
+++ b/comment-persistence-service/src/main/resources/application.properties
@@ -9,8 +9,9 @@ spring.config.import=classpath:application-common.properties
 # ===================================================================
 # DATABASE CONFIGURATION
 # ===================================================================
-spring.datasource.url=jdbc:h2:mem:commentdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
+spring.datasource.url=jdbc:postgresql://localhost:5432/commentdb
+spring.datasource.driverClassName=org.postgresql.Driver
+spring.datasource.username=postgres
+spring.datasource.password=postgres
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/compose.yaml
+++ b/compose.yaml
@@ -56,10 +56,8 @@ services:
     container_name: comment-publisher-app
     depends_on:
       - kafka
-      - mongo
     environment:
       - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - SPRING_DATA_MONGODB_URI=mongodb://mongo:27017/coderoute
 
   comment-persistence:
     build:
@@ -71,8 +69,12 @@ services:
     container_name: comment-persistence-app
     depends_on:
       - kafka
+      - postgres
     environment:
       - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/commentdb
+      - SPRING_DATASOURCE_USERNAME=postgres
+      - SPRING_DATASOURCE_PASSWORD=postgres
 
   # 2. Backing Infrastructure Services
   ollama:
@@ -116,14 +118,18 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
-  mongo:
-    image: mongo:latest
-    container_name: mongo-db
+  postgres:
+    image: postgres:16
+    container_name: postgres-db
     ports:
-      - "27017:27017"
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=commentdb
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
     volumes:
-      - mongo_data:/data/db
+      - postgres_data:/var/lib/postgresql/data
 
 volumes:
   ollama_data:
-  mongo_data:
+  postgres_data:


### PR DESCRIPTION
## Summary
- swap H2 runtime dependency for PostgreSQL in comment persistence service
- configure datasource properties for PostgreSQL
- add PostgreSQL service and env vars to docker compose
- remove MongoDB service and related variables from docker compose

## Testing
- `./mvnw -q -pl comment-persistence-service test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a074ae108328bab5e928da2c88d4